### PR TITLE
Fix deprecated config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ yarn add --dev \
 
 ## Usage
 
-Add this to your `.eslintrc` file:
+Add this to your `.eslintrc.json` file:
 
 ```json
 {


### PR DESCRIPTION
## What
- `.eslintrc` was deprecated. using `.eslintrc.json`.

<img width="955" alt="Configuring_ESLint_-_ESLint_-_Pluggable_JavaScript_linter" src="https://user-images.githubusercontent.com/1576804/67633808-fe62a900-f8f7-11e9-931c-0eafe567b2c8.png">

https://eslint.org/docs/user-guide/configuring#configuration-file-formats